### PR TITLE
Improve markdown generator

### DIFF
--- a/MarkdownTableMakerFive.gs
+++ b/MarkdownTableMakerFive.gs
@@ -241,11 +241,6 @@ var MarkdownTableMaker = function () {
     return sheet.getRange(1, 1, lastRow, lastColumn);
   }
 
-  // builds Markdown hyperlink
-  function _createHyperlinkMarkdown(title, url) {
-    return '[' + title + '](' + url +')';
-  }
-
   return {
 
     /**


### PR DESCRIPTION
We use the cell’s display value instead of object value, which is important for numbers and dates, as these now match the number/date formatter from the spreadsheet.

Alignment for a column is based on what alignment majority of cells use, ignoring the header.

The generated Markdown has columns padded so that they have the same width, and for the ASCII padding it will use the spreadsheet’s alignment, so it looks closer to the original spreadsheet.

For auto-detected URLs we use the `<url>` shorthand notation instead of `[url](url)`, although this feature is disabled by default.

Using the pipe character in a cell no longer causes it to be wrapped in `<code>` tags, as that should only be done if the cell is using a monospaced font.

When the cell is using a monospaced font, we still respect other formatting, like bold and italic, and we also support URLs and similar in cells with monospaced fonts, in this case we use a `<code>` tag instead of markdown’s raw mode (which would disable special markup).

Table headers do not get styled with bold or italic, since there will most likely be styling of table headers in the context where the markdown is being used (most browsers already make table headers bold by default).